### PR TITLE
Fix: Load data only once in the parent process

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,12 +12,19 @@ from fastapi import FastAPI
 
 from app.api.endpoints import api_router
 from app.core.logging import start_log_worker, stop_log_worker
-from app.services.data_loader import load_datasets_into_memory
+from app.services.data_loader import load_data_synchronously
 from app.services.filter_service import FilterService
 
 # Configura el logging para la aplicación
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+# --- Carga de Datos de Manera Síncrona en el Proceso Principal ---
+# Almacena los DataFrames cargados en una variable global.
+# Esto asegura que los datos se carguen solo una vez cuando el módulo es importado
+# por el proceso principal de Uvicorn, antes de que los workers sean bifurcados.
+preloaded_dataframes = load_data_synchronously()
 
 
 @asynccontextmanager
@@ -31,9 +38,10 @@ async def lifespan(app: FastAPI):
     start_log_worker()
 
     try:
-        dataframes = await load_datasets_into_memory()
-        app.state.filter_service = FilterService(dataframes)
-        logger.info("Servicio de filtrado inicializado correctamente.")
+        # Los datos ya están cargados en la variable global `preloaded_dataframes`.
+        # Simplemente inicializa el servicio con los datos pre-cargados.
+        app.state.filter_service = FilterService(preloaded_dataframes)
+        logger.info("Servicio de filtrado inicializado con datos pre-cargados.")
     except Exception as e:
         logger.critical(f"CRÍTICO: Fallo al inicializar la aplicación durante el inicio: {e}", exc_info=True)
         await stop_log_worker()

--- a/app/services/data_loader.py
+++ b/app/services/data_loader.py
@@ -116,3 +116,27 @@ async def load_datasets_into_memory() -> Dict[str, pl.DataFrame]:
         )
         # Re-lanza la excepción para detener el proceso de inicio de FastAPI.
         raise
+
+
+def load_data_synchronously() -> Dict[str, pl.DataFrame]:
+    """
+    Wrapper síncrono para cargar los datos.
+
+    Esta función inicializa el bucle de eventos de asyncio y ejecuta la
+    función asíncrona de carga de datos. Está diseñada para ser llamada
+    desde un contexto síncrono, como el inicio de un script principal.
+
+    Returns:
+        Un diccionario de DataFrames de Polars cargados.
+    """
+    logger.info("Iniciando el cargador de datos síncrono...")
+    try:
+        # asyncio.run() crea y gestiona un nuevo bucle de eventos
+        dataframes = asyncio.run(load_datasets_into_memory())
+        logger.info("El cargador de datos síncrono ha finalizado exitosamente.")
+        return dataframes
+    except Exception as e:
+        logger.critical(f"Fallo crítico en el cargador de datos síncrono: {e}", exc_info=True)
+        # Propaga la excepción para asegurar que el fallo en la carga de datos
+        # detenga el inicio de la aplicación.
+        raise


### PR DESCRIPTION
The application was hanging on startup when using multiple workers because each worker process was trying to download and load the same large Parquet files from Azure simultaneously.

This change refactors the data loading logic to ensure it runs only once in the main Uvicorn process before the worker processes are forked.

- A new synchronous function `load_data_synchronously` is added to `app/services/data_loader.py` to wrap the async loading logic.
- This function is called once in the global scope of `app/main.py`, and the resulting DataFrames are stored in a global variable.
- The application's `lifespan` manager is updated to use these pre-loaded DataFrames, preventing redundant data loading in the workers.

This resolves the startup issue and significantly improves the application's launch time in a multi-worker environment.