### PR TITLE
fix(asyncio): Resolve event loop conflict during startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,19 +12,12 @@ from fastapi import FastAPI
 
 from app.api.endpoints import api_router
 from app.core.logging import start_log_worker, stop_log_worker
-from app.services.data_loader import load_data_synchronously
+from app.services.data_loader import load_datasets_into_memory
 from app.services.filter_service import FilterService
 
 # Configura el logging para la aplicación
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-# --- Carga de Datos de Manera Síncrona en el Proceso Principal ---
-# Almacena los DataFrames cargados en una variable global.
-# Esto asegura que los datos se carguen solo una vez cuando el módulo es importado
-# por el proceso principal de Uvicorn, antes de que los workers sean bifurcados.
-preloaded_dataframes = load_data_synchronously()
 
 
 @asynccontextmanager
@@ -38,8 +31,10 @@ async def lifespan(app: FastAPI):
     start_log_worker()
 
     try:
-        # Los datos ya están cargados en la variable global `preloaded_dataframes`.
-        # Simplemente inicializa el servicio con los datos pre-cargados.
+        # Carga los datos de forma asíncrona y los almacena en el estado de la aplicación.
+        # Esto asegura que los datos se carguen después de que el bucle de eventos haya comenzado,
+        # evitando conflictos con asyncio.run().
+        preloaded_dataframes = await load_datasets_into_memory()
         app.state.filter_service = FilterService(preloaded_dataframes)
         logger.info("Servicio de filtrado inicializado con datos pre-cargados.")
     except Exception as e:

--- a/app/services/data_loader.py
+++ b/app/services/data_loader.py
@@ -118,25 +118,3 @@ async def load_datasets_into_memory() -> Dict[str, pl.DataFrame]:
         raise
 
 
-def load_data_synchronously() -> Dict[str, pl.DataFrame]:
-    """
-    Wrapper síncrono para cargar los datos.
-
-    Esta función inicializa el bucle de eventos de asyncio y ejecuta la
-    función asíncrona de carga de datos. Está diseñada para ser llamada
-    desde un contexto síncrono, como el inicio de un script principal.
-
-    Returns:
-        Un diccionario de DataFrames de Polars cargados.
-    """
-    logger.info("Iniciando el cargador de datos síncrono...")
-    try:
-        # asyncio.run() crea y gestiona un nuevo bucle de eventos
-        dataframes = asyncio.run(load_datasets_into_memory())
-        logger.info("El cargador de datos síncrono ha finalizado exitosamente.")
-        return dataframes
-    except Exception as e:
-        logger.critical(f"Fallo crítico en el cargador de datos síncrono: {e}", exc_info=True)
-        # Propaga la excepción para asegurar que el fallo en la carga de datos
-        # detenga el inicio de la aplicación.
-        raise


### PR DESCRIPTION
Refactors the data loading mechanism to prevent the `RuntimeError: asyncio.run() cannot be called from a running event loop`.

The error was caused by calling `asyncio.run()` from a synchronous function that was executed at the module level when each Uvicorn worker started. Since Uvicorn already manages an asyncio event loop, this created a conflict.

The fix involves:
- Removing the synchronous wrapper function `load_data_synchronously()`.
- Moving the asynchronous `load_datasets_into_memory()` call into the FastAPI `lifespan` context manager in `app/main.py`.

This ensures that data loading is performed asynchronously within the event loop managed by Uvicorn, which is the correct and idiomatic approach for startup tasks in FastAPI.