### PR TITLE
fix(azure): Gestionar ciclo de vida de cliente para evitar cierres de…

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -37,6 +37,7 @@ async def log_worker():
     `log_queue`. Los formatea y los envía a Azure Data Lake.
     """
     while True:
+        log_message = None
         try:
             log_message = await log_queue.get()
 
@@ -61,8 +62,11 @@ async def log_worker():
             # Si falla la escritura en Azure, registra el error en la consola.
             console_logger.error(f"Fallo al escribir el log en Azure: {e}", exc_info=True)
         finally:
-            # Señala que el elemento de la cola ha sido procesado.
-            log_queue.task_done()
+            # Señala que el elemento de la cola ha sido procesado, solo si se obtuvo uno.
+            # Esto evita el error 'task_done() called too many times' si la tarea es cancelada
+            # mientras espera en `log_queue.get()`.
+            if log_message is not None:
+                log_queue.task_done()
 
 
 async def queue_log_message(

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI
 
 from app.api.endpoints import api_router
 from app.core.logging import start_log_worker, stop_log_worker
+from app.services import azure_client
 from app.services.data_loader import load_datasets_into_memory
 from app.services.filter_service import FilterService
 
@@ -24,21 +25,23 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """
     Gestiona los eventos del ciclo de vida de la aplicación utilizando el protocolo lifespan moderno.
-    - Al inicio: Inicia el worker de logs, carga los datos e inicializa los servicios.
-    - Al apagar: Detiene de forma segura el worker de logs.
+    - Al inicio: Inicia servicios (logs, clientes de Azure) y precarga los datos.
+    - Al apagar: Cierra de forma segura los servicios en segundo plano.
     """
     logger.info("Iniciando la aplicación...")
+    # Inicia los servicios en segundo plano primero
     start_log_worker()
+    await azure_client.initialize_azure_clients()
 
     try:
         # Carga los datos de forma asíncrona y los almacena en el estado de la aplicación.
-        # Esto asegura que los datos se carguen después de que el bucle de eventos haya comenzado,
-        # evitando conflictos con asyncio.run().
         preloaded_dataframes = await load_datasets_into_memory()
         app.state.filter_service = FilterService(preloaded_dataframes)
         logger.info("Servicio de filtrado inicializado con datos pre-cargados.")
     except Exception as e:
         logger.critical(f"CRÍTICO: Fallo al inicializar la aplicación durante el inicio: {e}", exc_info=True)
+        # Asegura que los servicios iniciados se cierren en caso de fallo
+        await azure_client.close_azure_clients()
         await stop_log_worker()
         raise
 
@@ -46,7 +49,9 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    # --- Apagado de la aplicación ---
     logger.info("Comenzando el apagado de la aplicación...")
+    await azure_client.close_azure_clients()
     await stop_log_worker()
     logger.info("Apagado de la aplicación completado.")
 

--- a/app/services/azure_client.py
+++ b/app/services/azure_client.py
@@ -1,14 +1,13 @@
 """
 Cliente asíncrono para interactuar con los servicios de Azure Storage.
 
-Este módulo proporciona funciones para conectarse a Azure Blob Storage para leer
-archivos Parquet y a Azure Data Lake Storage Gen2 para escribir registros.
-Utiliza un patrón de fábrica con caché para reutilizar los clientes de servicio y
-las credenciales, mejorando el rendimiento y la gestión de recursos.
+Este módulo proporciona una gestión centralizada del ciclo de vida para los clientes de
+servicios de Azure, asegurando que se inicialicen al inicio de la aplicación y se
+cierren de forma segura al apagarse. Esto previene errores de 'Conexión cerrada'
+bajo cargas concurrentes al reutilizar una única sesión de transporte.
 """
-
-from functools import lru_cache
-from typing import Union
+import logging
+from typing import Optional, Union
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity.aio import DefaultAzureCredential
@@ -17,110 +16,118 @@ from azure.storage.filedatalake.aio import DataLakeServiceClient
 
 from app.core.config import settings
 
+logger = logging.getLogger(__name__)
 
-@lru_cache(maxsize=1)
+# --- Instancias de Cliente Gestionadas Globalmente ---
+_blob_service_client: Optional[BlobServiceClient] = None
+_datalake_service_client: Optional[DataLakeServiceClient] = None
+
+
 def _get_credential() -> Union[str, DefaultAzureCredential]:
     """
     Obtiene la credencial de Azure apropiada según la configuración.
     Usa una cadena de conexión si está disponible, de lo contrario, DefaultAzureCredential.
-    Esta función se almacena en caché para evitar volver a crear el objeto de credencial.
-
-    Returns:
-        La credencial de Azure configurada.
     """
     if settings.AZURE_STORAGE_CONNECTION_STRING:
         return settings.AZURE_STORAGE_CONNECTION_STRING
-    # DefaultAzureCredential usará variables de entorno para el principal de servicio
     return DefaultAzureCredential()
 
 
-@lru_cache(maxsize=1)
+async def initialize_azure_clients():
+    """
+    Inicializa los clientes de servicio de Azure asíncronos al inicio de la aplicación.
+    Esto abre las sesiones de transporte que serán reutilizadas en toda la aplicación.
+    """
+    global _blob_service_client, _datalake_service_client
+    logger.info("Inicializando clientes de Azure...")
+
+    credential = _get_credential()
+    if isinstance(credential, str):
+        # Usar cadena de conexión
+        blob_account_url = None
+        datalake_account_url = None
+        _blob_service_client = BlobServiceClient.from_connection_string(credential)
+        _datalake_service_client = DataLakeServiceClient.from_connection_string(credential)
+    else:
+        # Usar DefaultAzureCredential
+        blob_account_url = f"https://{settings.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
+        datalake_account_url = f"https://{settings.AZURE_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net"
+        _blob_service_client = BlobServiceClient(account_url=blob_account_url, credential=credential)
+        _datalake_service_client = DataLakeServiceClient(account_url=datalake_account_url, credential=credential)
+
+    # Entra en el contexto del gestor para abrir la sesión de red
+    await _blob_service_client.__aenter__()
+    await _datalake_service_client.__aenter__()
+    logger.info("Clientes de Azure inicializados y listos.")
+
+
+async def close_azure_clients():
+    """
+    Cierra de forma segura los clientes de servicio de Azure durante el apagado de la aplicación.
+    """
+    global _blob_service_client, _datalake_service_client
+    logger.info("Cerrando clientes de Azure...")
+    if _blob_service_client:
+        await _blob_service_client.__aexit__(None, None, None)
+    if _datalake_service_client:
+        await _datalake_service_client.__aexit__(None, None, None)
+    logger.info("Clientes de Azure cerrados de forma segura.")
+
+
 def get_blob_service_client() -> BlobServiceClient:
     """
-    Crea y devuelve una única instancia en caché de BlobServiceClient.
-
-    Returns:
-        Una instancia asíncrona de BlobServiceClient.
+    Devuelve la instancia global inicializada de BlobServiceClient.
     """
-    credential = _get_credential()
-    if isinstance(credential, str):
-        return BlobServiceClient.from_connection_string(credential)
-
-    account_url = f"https://{settings.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
-    return BlobServiceClient(account_url=account_url, credential=credential)
+    if not _blob_service_client:
+        raise RuntimeError("El BlobServiceClient no ha sido inicializado.")
+    return _blob_service_client
 
 
-@lru_cache(maxsize=1)
 def get_datalake_service_client() -> DataLakeServiceClient:
     """
-    Crea y devuelve una única instancia en caché de DataLakeServiceClient.
-
-    Returns:
-        Una instancia asíncrona de DataLakeServiceClient.
+    Devuelve la instancia global inicializada de DataLakeServiceClient.
     """
-    credential = _get_credential()
-    if isinstance(credential, str):
-        return DataLakeServiceClient.from_connection_string(credential)
-
-    account_url = f"https://{settings.AZURE_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net"
-    return DataLakeServiceClient(account_url=account_url, credential=credential)
+    if not _datalake_service_client:
+        raise RuntimeError("El DataLakeServiceClient no ha sido inicializado.")
+    return _datalake_service_client
 
 
 async def download_parquet_file_async(file_name: str) -> bytes:
     """
     Descarga un archivo Parquet específico desde Azure Blob Storage.
-
-    Args:
-        file_name: El nombre del blob (archivo) a descargar.
-
-    Returns:
-        El contenido del archivo como bytes.
-
-    Raises:
-        FileNotFoundError: Si el archivo especificado no existe en el contenedor.
+    Utiliza el cliente de servicio gestionado globalmente.
     """
     blob_service_client = get_blob_service_client()
-    async with blob_service_client:
-        container_client = blob_service_client.get_container_client(settings.AZURE_BLOB_CONTAINER_NAME)
-        try:
-            blob_client = container_client.get_blob_client(file_name)
-            download_stream = await blob_client.download_blob()
-            data = await download_stream.readall()
-            return data
-        except ResourceNotFoundError:
-            raise FileNotFoundError(
-                f"El archivo Parquet '{file_name}' no se encontró en el contenedor "
-                f"'{settings.AZURE_BLOB_CONTAINER_NAME}'."
-            )
+    container_client = blob_service_client.get_container_client(settings.AZURE_BLOB_CONTAINER_NAME)
+    try:
+        blob_client = container_client.get_blob_client(file_name)
+        download_stream = await blob_client.download_blob()
+        data = await download_stream.readall()
+        return data
+    except ResourceNotFoundError:
+        raise FileNotFoundError(
+            f"El archivo Parquet '{file_name}' no se encontró en el contenedor "
+            f"'{settings.AZURE_BLOB_CONTAINER_NAME}'."
+        )
 
 
 async def write_log_async(file_path: str, log_data: bytes):
     """
     Añade una entrada de registro a un archivo en Azure Data Lake Storage.
-
-    Esta función maneja la creación del archivo si no existe y añade los datos
-    de forma atómica. Sin embargo, para prevenir condiciones de carrera de múltiples
-    escritores concurrentes (ej., en un entorno escalado horizontalmente), esta función
-    debería ser llamada desde un contexto serializado, como una única tarea trabajadora
-    en segundo plano.
-
-    Args:
-        file_path: La ruta completa al archivo de registro en el Data Lake.
-        log_data: Los datos de registro a añadir, codificados como bytes.
+    Utiliza el cliente de servicio gestionado globalmente.
     """
     datalake_service_client = get_datalake_service_client()
-    async with datalake_service_client:
-        file_system_client = datalake_service_client.get_file_system_client(
-            settings.AZURE_DATALAKE_FILESYSTEM_NAME
-        )
-        file_client = file_system_client.get_file_client(file_path)
+    file_system_client = datalake_service_client.get_file_system_client(
+        settings.AZURE_DATALAKE_FILESYSTEM_NAME
+    )
+    file_client = file_system_client.get_file_client(file_path)
 
-        try:
-            properties = await file_client.get_properties()
-            offset = properties.size
-        except ResourceNotFoundError:
-            await file_client.create_file()
-            offset = 0
+    try:
+        properties = await file_client.get_properties()
+        offset = properties.size
+    except ResourceNotFoundError:
+        await file_client.create_file()
+        offset = 0
 
-        await file_client.append_data(data=log_data, offset=offset)
-        await file_client.flush_data(offset=offset + len(log_data))
+    await file_client.append_data(data=log_data, offset=offset)
+    await file_client.flush_data(offset=offset + len(log_data))


### PR DESCRIPTION
… conexión

Refactoriza la gestión de los clientes de Azure (`BlobServiceClient` y `DataLakeServiceClient`) para que sean gestionados como instancias globales únicas durante el ciclo de vida de la aplicación.

- Introduce `initialize_azure_clients` y `close_azure_clients` en `azure_client.py` para manejar explícitamente el inicio y cierre de las sesiones de cliente.
- Integra estas funciones en el `lifespan` de FastAPI en `main.py`, asegurando que los clientes se inicialicen al arrancar y se cierren de forma segura al apagar.
- Elimina los bloques `async with` en las funciones de descarga individuales, que causaban que la conexión compartida se cerrara prematuramente durante las descargas concurrentes.

Esto resuelve el error `RuntimeError: Connection closed` que ocurría durante la carga de datos al inicio.

Adicionalmente, se corrige una condición de carrera en el `log_worker` (`logging.py`) que causaba un `ValueError: task_done() called too many times` si la aplicación fallaba al iniciar. La llamada a `task_done()` ahora está protegida para ejecutarse solo si se ha recuperado un mensaje de la cola.