### PR TITLE
Fix(data_loader): Ensure dataset key is generated from filename

### DIFF
--- a/app/services/data_loader.py
+++ b/app/services/data_loader.py
@@ -5,6 +5,7 @@ Servicio para cargar conjuntos de datos desde Azure a la memoria en el inicio de
 import asyncio
 import io
 import logging
+import os
 from typing import Dict, Tuple
 
 import polars as pl
@@ -48,12 +49,16 @@ async def _download_and_load_one_parquet(file_name: str) -> Tuple[str, pl.DataFr
     try:
         parquet_bytes = await download_parquet_file_async(file_name)
         dataframe = pl.read_parquet(io.BytesIO(parquet_bytes))
-        dataset_key = file_name.removesuffix(".parquet")
+
+        # Extrae solo el nombre del archivo para usarlo como clave y para la búsqueda de ordenación
+        base_file_name = os.path.basename(file_name)
+        dataset_key = base_file_name.removesuffix(".parquet")
+
         logger.info(f"'{file_name}' cargado exitosamente. Shape: {dataframe.shape}. Pre-ordenando...")
 
         # Pre-ordena el DataFrame para rendimiento si se define una clave de ordenación
-        if file_name in SORT_KEY_MAP:
-            sort_columns = SORT_KEY_MAP[file_name]
+        if base_file_name in SORT_KEY_MAP:
+            sort_columns = SORT_KEY_MAP[base_file_name]
             # Asegura que todas las columnas de ordenación existan en el DataFrame antes de ordenar
             missing_cols = [col for col in sort_columns if col not in dataframe.columns]
             if not missing_cols:
@@ -65,7 +70,7 @@ async def _download_and_load_one_parquet(file_name: str) -> Tuple[str, pl.DataFr
                     "Continuando con datos sin ordenar."
                 )
         else:
-            logger.info(f"No se ha definido una clave de pre-ordenación para '{file_name}'.")
+            logger.info(f"No se ha definido una clave de pre-ordenación para '{base_file_name}'.")
 
         logger.info(f"Procesamiento de '{dataset_key}' finalizado.")
         return dataset_key, dataframe


### PR DESCRIPTION
The `FilterService` expects dataset keys to be the basename of the parquet file (e.g., 'api_movimientoaction0'). However, the `data_loader` was generating the key from the full path provided in the environment variables.

This commit fixes the issue by using `os.path.basename()` to extract just the filename from the path before creating the dataset key. This ensures the keys in the loaded dataframes dictionary match the keys expected by the service layer, resolving the 'dataset not found' error.