### PR TITLE
Refactor data loading and simplify Azure authentication

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -15,17 +15,12 @@ class Settings(BaseSettings):
     """
     Gestiona la configuración de la aplicación mediante variables de entorno.
 
-    Esta clase carga la configuración desde un archivo .env y la valida,
-    asegurando que se proporcione un método de autenticación de Azure válido.
+    Esta clase carga la configuración desde un archivo .env y la valida.
+    La autenticación con Azure se realiza exclusivamente mediante una cadena de conexión.
 
     Atributos:
-        AZURE_STORAGE_CONNECTION_STRING (Optional[str]): La cadena de conexión para la
-            cuenta de Azure Storage. Preferido por simplicidad.
-        AZURE_STORAGE_ACCOUNT_NAME (Optional[str]): El nombre de la cuenta de almacenamiento.
-            Utilizado para la autenticación con principal de servicio.
-        AZURE_TENANT_ID (Optional[str]): El ID del inquilino de Azure Active Directory.
-        AZURE_CLIENT_ID (Optional[str]): El ID de cliente del principal de servicio.
-        AZURE_CLIENT_SECRET (Optional[str]): El secreto de cliente del principal de servicio.
+        AZURE_STORAGE_CONNECTION_STRING (str): La cadena de conexión para la
+            cuenta de Azure Storage. Es obligatoria.
         AZURE_BLOB_CONTAINER_NAME (str): El nombre del contenedor en Azure Blob
             Storage donde se encuentran los archivos Parquet.
         AZURE_DATALAKE_FILESYSTEM_NAME (str): El nombre del sistema de archivos en Azure
@@ -33,14 +28,8 @@ class Settings(BaseSettings):
         LOG_FILE_PATH_TEMPLATE (str): Una cadena de plantilla para la ruta del archivo de registro en
             el Data Lake, con marcadores de posición para partes de la fecha.
     """
-    # --- Configuración General de Azure Storage ---
-    AZURE_STORAGE_CONNECTION_STRING: Optional[str] = None
-    AZURE_STORAGE_ACCOUNT_NAME: Optional[str] = None
-    AZURE_TENANT_ID: Optional[str] = None
-    AZURE_CLIENT_ID: Optional[str] = None
-    AZURE_CLIENT_SECRET: Optional[str] = None
-
-    # --- Nombres de Contenedores y Sistemas de Archivos ---
+    # --- Configuración de Azure Storage ---
+    AZURE_STORAGE_CONNECTION_STRING: str
     AZURE_BLOB_CONTAINER_NAME: str
     AZURE_DATALAKE_FILESYSTEM_NAME: str
 
@@ -66,38 +55,6 @@ class Settings(BaseSettings):
             ]
             if name is not None
         ]
-        return self
-
-    @model_validator(mode='after')
-    def _check_azure_auth_method(self) -> 'Settings':
-        """
-        Valida que se haya configurado exactamente un método de autenticación de Azure.
-
-        Raises:
-            ValueError: Si ambos o ninguno de los métodos de autenticación están configurados.
-        """
-        sp_auth_vars = [
-            self.AZURE_STORAGE_ACCOUNT_NAME,
-            self.AZURE_TENANT_ID,
-            self.AZURE_CLIENT_ID,
-            self.AZURE_CLIENT_SECRET,
-        ]
-
-        using_connection_string = self.AZURE_STORAGE_CONNECTION_STRING is not None
-        using_service_principal = all(v is not None for v in sp_auth_vars)
-
-        if using_connection_string and using_service_principal:
-            raise ValueError(
-                "Configuración ambigua: Se proporcionaron tanto AZURE_STORAGE_CONNECTION_STRING como "
-                "las credenciales del principal de servicio. Por favor, use solo uno."
-            )
-
-        if not using_connection_string and not using_service_principal:
-            raise ValueError(
-                "Configuración faltante: Proporcione AZURE_STORAGE_CONNECTION_STRING o "
-                "todas las credenciales del principal de servicio (AZURE_STORAGE_ACCOUNT_NAME, "
-                "AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET)."
-            )
         return self
 
     # Configura Pydantic para cargar desde un archivo .env e ignorar variables extra

--- a/app/services/azure_client.py
+++ b/app/services/azure_client.py
@@ -1,101 +1,86 @@
 """
-Cliente asíncrono para interactuar con los servicios de Azure Storage.
+Cliente asíncrono para interactuar con Azure Blob Storage.
 
-Este módulo proporciona una gestión centralizada del ciclo de vida para los clientes de
-servicios de Azure, asegurando que se inicialicen al inicio de la aplicación y se
-cierren de forma segura al apagarse. Esto previene errores de 'Conexión cerrada'
+Este módulo proporciona una gestión centralizada del ciclo de vida para el cliente
+de Blob Storage, asegurando que se inicialice al inicio de la aplicación y se
+cierre de forma segura al apagarse. Esto previene errores de 'Conexión cerrada'
 bajo cargas concurrentes al reutilizar una única sesión de transporte.
+La autenticación se realiza exclusivamente mediante la cadena de conexión.
 """
 import logging
-from typing import Optional, Union
+from typing import Optional
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity.aio import DefaultAzureCredential
 from azure.storage.blob.aio import BlobServiceClient
-from azure.storage.filedatalake.aio import DataLakeServiceClient
 
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-# --- Instancias de Cliente Gestionadas Globalmente ---
+# --- Instancia de Cliente Gestionada Globalmente ---
 _blob_service_client: Optional[BlobServiceClient] = None
-_datalake_service_client: Optional[DataLakeServiceClient] = None
-
-
-def _get_credential() -> Union[str, DefaultAzureCredential]:
-    """
-    Obtiene la credencial de Azure apropiada según la configuración.
-    Usa una cadena de conexión si está disponible, de lo contrario, DefaultAzureCredential.
-    """
-    if settings.AZURE_STORAGE_CONNECTION_STRING:
-        return settings.AZURE_STORAGE_CONNECTION_STRING
-    return DefaultAzureCredential()
 
 
 async def initialize_azure_clients():
     """
-    Inicializa los clientes de servicio de Azure asíncronos al inicio de la aplicación.
-    Esto abre las sesiones de transporte que serán reutilizadas en toda la aplicación.
+    Inicializa el BlobServiceClient asíncrono usando la cadena de conexión
+    al inicio de la aplicación. Esto abre la sesión de transporte que será
+    reutilizada en toda la aplicación.
     """
-    global _blob_service_client, _datalake_service_client
-    logger.info("Inicializando clientes de Azure...")
+    global _blob_service_client
+    logger.info("Inicializando cliente de Azure Blob Storage...")
 
-    credential = _get_credential()
-    if isinstance(credential, str):
-        # Usar cadena de conexión
-        blob_account_url = None
-        datalake_account_url = None
-        _blob_service_client = BlobServiceClient.from_connection_string(credential)
-        _datalake_service_client = DataLakeServiceClient.from_connection_string(credential)
-    else:
-        # Usar DefaultAzureCredential
-        blob_account_url = f"https://{settings.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
-        datalake_account_url = f"https://{settings.AZURE_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net"
-        _blob_service_client = BlobServiceClient(account_url=blob_account_url, credential=credential)
-        _datalake_service_client = DataLakeServiceClient(account_url=datalake_account_url, credential=credential)
+    if not settings.AZURE_STORAGE_CONNECTION_STRING:
+        raise ValueError("AZURE_STORAGE_CONNECTION_STRING no está configurada.")
+
+    _blob_service_client = BlobServiceClient.from_connection_string(
+        settings.AZURE_STORAGE_CONNECTION_STRING
+    )
 
     # Entra en el contexto del gestor para abrir la sesión de red
     await _blob_service_client.__aenter__()
-    await _datalake_service_client.__aenter__()
-    logger.info("Clientes de Azure inicializados y listos.")
+    logger.info("Cliente de Azure Blob Storage inicializado y listo.")
 
 
 async def close_azure_clients():
     """
-    Cierra de forma segura los clientes de servicio de Azure durante el apagado de la aplicación.
+    Cierra de forma segura el BlobServiceClient durante el apagado de la aplicación.
     """
-    global _blob_service_client, _datalake_service_client
-    logger.info("Cerrando clientes de Azure...")
+    global _blob_service_client
+    logger.info("Cerrando cliente de Azure Blob Storage...")
     if _blob_service_client:
         await _blob_service_client.__aexit__(None, None, None)
-    if _datalake_service_client:
-        await _datalake_service_client.__aexit__(None, None, None)
-    logger.info("Clientes de Azure cerrados de forma segura.")
+    logger.info("Cliente de Azure Blob Storage cerrado de forma segura.")
 
 
 def get_blob_service_client() -> BlobServiceClient:
     """
     Devuelve la instancia global inicializada de BlobServiceClient.
+
+    Raises:
+        RuntimeError: Si el cliente no ha sido inicializado.
     """
     if not _blob_service_client:
-        raise RuntimeError("El BlobServiceClient no ha sido inicializado.")
+        raise RuntimeError("El BlobServiceClient no ha sido inicializado. "
+                           "Asegúrate de que se llame a `initialize_azure_clients` "
+                           "al inicio de la aplicación.")
     return _blob_service_client
-
-
-def get_datalake_service_client() -> DataLakeServiceClient:
-    """
-    Devuelve la instancia global inicializada de DataLakeServiceClient.
-    """
-    if not _datalake_service_client:
-        raise RuntimeError("El DataLakeServiceClient no ha sido inicializado.")
-    return _datalake_service_client
 
 
 async def download_parquet_file_async(file_name: str) -> bytes:
     """
     Descarga un archivo Parquet específico desde Azure Blob Storage.
     Utiliza el cliente de servicio gestionado globalmente.
+
+    Args:
+        file_name: El nombre del archivo a descargar.
+
+    Returns:
+        Los bytes del archivo descargado.
+
+    Raises:
+        FileNotFoundError: Si el archivo no se encuentra en el contenedor.
+        RuntimeError: Si el cliente de blob no está inicializado.
     """
     blob_service_client = get_blob_service_client()
     container_client = blob_service_client.get_container_client(settings.AZURE_BLOB_CONTAINER_NAME)
@@ -105,29 +90,9 @@ async def download_parquet_file_async(file_name: str) -> bytes:
         data = await download_stream.readall()
         return data
     except ResourceNotFoundError:
+        logger.error(f"El archivo Parquet '{file_name}' no se encontró en el contenedor "
+                     f"'{settings.AZURE_BLOB_CONTAINER_NAME}'.")
         raise FileNotFoundError(
             f"El archivo Parquet '{file_name}' no se encontró en el contenedor "
             f"'{settings.AZURE_BLOB_CONTAINER_NAME}'."
         )
-
-
-async def write_log_async(file_path: str, log_data: bytes):
-    """
-    Añade una entrada de registro a un archivo en Azure Data Lake Storage.
-    Utiliza el cliente de servicio gestionado globalmente.
-    """
-    datalake_service_client = get_datalake_service_client()
-    file_system_client = datalake_service_client.get_file_system_client(
-        settings.AZURE_DATALAKE_FILESYSTEM_NAME
-    )
-    file_client = file_system_client.get_file_client(file_path)
-
-    try:
-        properties = await file_client.get_properties()
-        offset = properties.size
-    except ResourceNotFoundError:
-        await file_client.create_file()
-        offset = 0
-
-    await file_client.append_data(data=log_data, offset=offset)
-    await file_client.flush_data(offset=offset + len(log_data))

--- a/app/services/data_loader.py
+++ b/app/services/data_loader.py
@@ -1,12 +1,12 @@
 """
-Servicio para cargar conjuntos de datos desde Azure a la memoria en el inicio de la aplicación.
+Servicio para cargar y procesar cada conjunto de datos Parquet de forma independiente
+desde Azure a la memoria al inicio de la aplicación.
 """
 
 import asyncio
 import io
 import logging
-import os
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import polars as pl
 
@@ -16,110 +16,99 @@ from app.services.azure_client import download_parquet_file_async
 logger = logging.getLogger(__name__)
 
 
-# Un mapeo de nombres de archivo a las columnas por las que deben ordenarse para optimización.
-SORT_KEY_MAP = {
-    "api_movimientoaction0.parquet": [
-        "OrdenanteId", "TipoIdOrdenante", "Product", "EffectiveDateStr", "Reference"
-    ],
-    "api_movimientoaction1.parquet": [
-        "OrdenanteId", "TipoIdOrdenante", "Product", "EffectiveDateStr"
-    ],
-    "api_movimientoaction2.parquet": [
-        "OrdenanteId", "TipoIdOrdenante", "Product", "EventNum", "Reference"
-    ],
-}
-
-
-async def _download_and_load_one_parquet(file_name: str) -> Tuple[str, pl.DataFrame]:
+async def _load_movimientoaction0(file_name: str) -> Optional[Tuple[str, pl.DataFrame]]:
     """
-    Descarga un único archivo Parquet desde Azure, lo carga en un DataFrame de Polars,
-    y lo pre-ordena para optimización de consultas.
-
-    Args:
-        file_name: El nombre del archivo Parquet a procesar.
-
-    Returns:
-        Una tupla que contiene la clave del conjunto de datos y el DataFrame cargado y ordenado.
-
-    Raises:
-        FileNotFoundError: Si no se encuentra el archivo en Azure Blob Storage.
-        Exception: Para otros errores durante la descarga o el procesamiento.
+    Descarga, carga y pre-ordena el archivo 'movimientoaction0'.
     """
-    logger.info(f"Iniciando descarga de '{file_name}'...")
+    logger.info(f"Procesando '{file_name}'...")
     try:
         parquet_bytes = await download_parquet_file_async(file_name)
-        dataframe = pl.read_parquet(io.BytesIO(parquet_bytes))
+        df = pl.read_parquet(io.BytesIO(parquet_bytes))
+        logger.info(f"'{file_name}' cargado. Shape: {df.shape}. Pre-ordenando...")
 
-        # Extrae solo el nombre del archivo para usarlo como clave y para la búsqueda de ordenación
-        base_file_name = os.path.basename(file_name)
-        dataset_key = base_file_name.removesuffix(".parquet")
-
-        logger.info(f"'{file_name}' cargado exitosamente. Shape: {dataframe.shape}. Pre-ordenando...")
-
-        # Pre-ordena el DataFrame para rendimiento si se define una clave de ordenación
-        if base_file_name in SORT_KEY_MAP:
-            sort_columns = SORT_KEY_MAP[base_file_name]
-            # Asegura que todas las columnas de ordenación existan en el DataFrame antes de ordenar
-            missing_cols = [col for col in sort_columns if col not in dataframe.columns]
-            if not missing_cols:
-                dataframe = dataframe.sort(sort_columns)
-                logger.info(f"DataFrame '{dataset_key}' ordenado por {sort_columns}.")
-            else:
-                logger.warning(
-                    f"No se puede ordenar '{dataset_key}': Faltan columnas {missing_cols}. "
-                    "Continuando con datos sin ordenar."
-                )
-        else:
-            logger.info(f"No se ha definido una clave de pre-ordenación para '{base_file_name}'.")
-
-        logger.info(f"Procesamiento de '{dataset_key}' finalizado.")
-        return dataset_key, dataframe
-    except FileNotFoundError:
-        logger.critical(f"No se encontró el conjunto de datos '{file_name}'. La aplicación podría no funcionar correctamente.")
+        sort_columns = ["OrdenanteId", "TipoIdOrdenante", "Product", "EffectiveDateStr", "Reference"]
+        df = df.sort(sort_columns)
+        logger.info(f"DataFrame 'movimientoaction0' ordenado por {sort_columns}.")
+        return "movimientoaction0", df
+    except (FileNotFoundError, Exception) as e:
+        logger.critical(f"Fallo al cargar o procesar '{file_name}': {e}", exc_info=True)
         raise
-    except Exception as e:
-        logger.critical(f"Fallo al cargar el conjunto de datos '{file_name}': {e}", exc_info=True)
+
+
+async def _load_movimientoaction1(file_name: str) -> Optional[Tuple[str, pl.DataFrame]]:
+    """
+    Descarga, carga y pre-ordena el archivo 'movimientoaction1'.
+    """
+    logger.info(f"Procesando '{file_name}'...")
+    try:
+        parquet_bytes = await download_parquet_file_async(file_name)
+        df = pl.read_parquet(io.BytesIO(parquet_bytes))
+        logger.info(f"'{file_name}' cargado. Shape: {df.shape}. Pre-ordenando...")
+
+        sort_columns = ["OrdenanteId", "TipoIdOrdenante", "Product", "EffectiveDateStr"]
+        df = df.sort(sort_columns)
+        logger.info(f"DataFrame 'movimientoaction1' ordenado por {sort_columns}.")
+        return "movimientoaction1", df
+    except (FileNotFoundError, Exception) as e:
+        logger.critical(f"Fallo al cargar o procesar '{file_name}': {e}", exc_info=True)
+        raise
+
+
+async def _load_movimientoaction2(file_name: str) -> Optional[Tuple[str, pl.DataFrame]]:
+    """
+    Descarga, carga y pre-ordena el archivo 'movimientoaction2'.
+    """
+    logger.info(f"Procesando '{file_name}'...")
+    try:
+        parquet_bytes = await download_parquet_file_async(file_name)
+        df = pl.read_parquet(io.BytesIO(parquet_bytes))
+        logger.info(f"'{file_name}' cargado. Shape: {df.shape}. Pre-ordenando...")
+
+        sort_columns = ["OrdenanteId", "TipoIdOrdenante", "Product", "EventNum", "Reference"]
+        df = df.sort(sort_columns)
+        logger.info(f"DataFrame 'movimientoaction2' ordenado por {sort_columns}.")
+        return "movimientoaction2", df
+    except (FileNotFoundError, Exception) as e:
+        logger.critical(f"Fallo al cargar o procesar '{file_name}': {e}", exc_info=True)
         raise
 
 
 async def load_datasets_into_memory() -> Dict[str, pl.DataFrame]:
     """
-    Descarga concurrentemente todos los archivos Parquet especificados desde Azure Blob Storage
-    y los carga en un diccionario de DataFrames de Polars.
+    Descarga y carga de forma concurrente los conjuntos de datos Parquet configurados.
 
-    Esta función está destinada a ser llamada una vez en el inicio de la aplicación.
-
-    Returns:
-        Un diccionario donde las claves son nombres de conjuntos de datos (ej., 'dataset1') y
-        los valores son los correspondientes DataFrames de Polars.
-
-    Raises:
-        Exception: Si alguno de los conjuntos de datos falla al cargar, la excepción se
-                   propaga para detener el inicio de la aplicación.
+    Cada conjunto de datos se carga mediante una función específica que maneja su
+    propia lógica de procesamiento y ordenación.
     """
-    file_names = settings.parquet_files
-    logger.info(f"Iniciando proceso de carga de datos para los archivos: {file_names}")
+    tasks = []
+    file_mapping = {
+        "PARQUET_FILE_NAME_0": (_load_movimientoaction0, settings.PARQUET_FILE_NAME_0),
+        "PARQUET_FILE_NAME_1": (_load_movimientoaction1, settings.PARQUET_FILE_NAME_1),
+        "PARQUET_FILE_NAME_2": (_load_movimientoaction2, settings.PARQUET_FILE_NAME_2),
+    }
 
-    tasks = [_download_and_load_one_parquet(file_name) for file_name in file_names]
+    logger.info(f"Iniciando carga de datos para los archivos: {settings.parquet_files}")
 
-    # asyncio.gather ejecuta todas las tareas de descarga/carga concurrentemente.
-    # Si alguna tarea lanza una excepción, gather la propagará inmediatamente.
+    for key, (loader_func, file_name) in file_mapping.items():
+        if file_name:
+            tasks.append(loader_func(file_name))
+
+    if not tasks:
+        logger.warning("No se ha configurado ningún archivo Parquet para cargar.")
+        return {}
+
     try:
         results = await asyncio.gather(*tasks)
-
-        dataframes = {key: df for key, df in results}
-
-        if len(dataframes) != len(file_names):
-            logger.warning("Discrepancia entre los dataframes cargados y los nombres de archivo solicitados.")
+        # Filtra cualquier resultado None que pueda ocurrir si una tarea falla y es manejada
+        dataframes = {key: df for key, df in results if key and df is not None}
 
         logger.info(f"{len(dataframes)} conjunto(s) de datos cargado(s) exitosamente en memoria.")
         return dataframes
     except Exception as e:
         logger.critical(
-            f"Ocurrió un error crítico durante la carga del conjunto de datos: {e}. "
+            f"Ocurrió un error crítico durante la carga concurrente de datos: {e}. "
             "El inicio de la aplicación será abortado."
         )
-        # Re-lanza la excepción para detener el proceso de inicio de FastAPI.
         raise
 
 


### PR DESCRIPTION
- Separated the data loading process into independent functions for each Parquet file to ensure each is loaded and processed once, avoiding recycled code.
- Removed Azure Service Principal authentication, relying solely on the connection string from the .env file for a simpler and more direct connection.
- Cleaned up the Azure client by removing the DataLakeServiceClient and related logic, focusing exclusively on Blob Storage for Parquet files.